### PR TITLE
feat: add rainbow-themed styling and table layout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -61,9 +61,9 @@ function App() {
   }
 
   return (
-    <div style={{ margin: "2rem" }}>
+    <div className="container">
       <h1>Girls</h1>
-      <form onSubmit={handleSubmit} style={{ marginBottom: "1rem" }}>
+      <form onSubmit={handleSubmit}>
         <input
           placeholder="First name"
           value={form.first_name}
@@ -93,91 +93,135 @@ function App() {
           <option>Left</option>
           <option>Rejected</option>
         </select>
-        <button type="submit">Add</button>
+        <button type="submit" className="btn">Add</button>
       </form>
 
-      <ul>
-        {girls.map((g) => (
-          <li key={g.id}>
-            {editingId === g.id ? (
-              <>
-                <input
-                  placeholder="First name"
-                  value={editForm.first_name}
-                  onChange={(e) =>
-                    setEditForm({ ...editForm, first_name: e.target.value })
-                  }
-                  required
-                />
-                <input
-                  placeholder="Last name"
-                  value={editForm.last_name}
-                  onChange={(e) =>
-                    setEditForm({ ...editForm, last_name: e.target.value })
-                  }
-                  required
-                />
-                <input
-                  type="date"
-                  value={editForm.date_of_birth}
-                  onChange={(e) =>
-                    setEditForm({ ...editForm, date_of_birth: e.target.value })
-                  }
-                  required
-                />
-                <select
-                  value={editForm.state}
-                  onChange={(e) =>
-                    setEditForm({ ...editForm, state: e.target.value })
-                  }
-                >
-                  <option>Registered</option>
-                  <option>Approved</option>
-                  <option>Member</option>
-                  <option>Leaver</option>
-                  <option>Left</option>
-                  <option>Rejected</option>
-                </select>
-                <button type="button" onClick={() => saveEdit(g.id)}>
-                  Save
-                </button>
-                <button type="button" onClick={() => setEditingId(null)}>
-                  Cancel
-                </button>
-              </>
+      <table className="girls-table">
+        <thead>
+          <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Date of Birth</th>
+            <th>State</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {girls.map((g) =>
+            editingId === g.id ? (
+              <tr key={g.id}>
+                <td>
+                  <input
+                    placeholder="First name"
+                    value={editForm.first_name}
+                    onChange={(e) =>
+                      setEditForm({ ...editForm, first_name: e.target.value })
+                    }
+                    required
+                  />
+                </td>
+                <td>
+                  <input
+                    placeholder="Last name"
+                    value={editForm.last_name}
+                    onChange={(e) =>
+                      setEditForm({ ...editForm, last_name: e.target.value })
+                    }
+                    required
+                  />
+                </td>
+                <td>
+                  <input
+                    type="date"
+                    value={editForm.date_of_birth}
+                    onChange={(e) =>
+                      setEditForm({
+                        ...editForm,
+                        date_of_birth: e.target.value,
+                      })
+                    }
+                    required
+                  />
+                </td>
+                <td>
+                  <select
+                    value={editForm.state}
+                    onChange={(e) =>
+                      setEditForm({ ...editForm, state: e.target.value })
+                    }
+                  >
+                    <option>Registered</option>
+                    <option>Approved</option>
+                    <option>Member</option>
+                    <option>Leaver</option>
+                    <option>Left</option>
+                    <option>Rejected</option>
+                  </select>
+                </td>
+                <td className="actions">
+                  <button
+                    type="button"
+                    className="btn"
+                    onClick={() => saveEdit(g.id)}
+                  >
+                    Save
+                  </button>
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    onClick={() => setEditingId(null)}
+                  >
+                    Cancel
+                  </button>
+                </td>
+              </tr>
             ) : (
-              <>
-                {g.first_name} {g.last_name} — {g.date_of_birth} ({g.state})
-                <button type="button" onClick={() => viewRecord(g.id)}>
-                  Record
-                </button>
-                <button type="button" onClick={() => startEdit(g)}>
-                  Edit
-                </button>
-                <button type="button" onClick={() => deleteGirl(g.id)}>
-                  Delete
-                </button>
-              </>
-            )}
-          </li>
-        ))}
-      </ul>
+              <tr key={g.id}>
+                <td>{g.first_name}</td>
+                <td>{g.last_name}</td>
+                <td>{g.date_of_birth}</td>
+                <td>{g.state}</td>
+                <td className="actions">
+                  <button
+                    type="button"
+                    className="btn"
+                    onClick={() => viewRecord(g.id)}
+                  >
+                    Record
+                  </button>
+                  <button
+                    type="button"
+                    className="btn"
+                    onClick={() => startEdit(g)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    className="btn btn-danger"
+                    onClick={() => deleteGirl(g.id)}
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            )
+          )}
+        </tbody>
+      </table>
 
       {record && (
-        <div
-          style={{
-            marginTop: "2rem",
-            padding: "1rem",
-            border: "1px solid #ccc",
-            maxWidth: "400px",
-          }}
-        >
+        <div className="record-card">
           <h2>
             Record for {record.first_name} {record.last_name}
           </h2>
           <p>Date of Birth: {record.date_of_birth}</p>
           <p>State: {record.state}</p>
-          <button type="button" onClick={() => setRecord(null)}>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={() => setRecord(null)}
+          >
             Close
           </button>
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,117 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+  /* Rainbow brand palette */
+  --color-purple: #6a1b9a;
+  --color-blue: #0072ce;
+  --color-green: #00a95c;
+  --color-yellow: #ffd100;
+  --color-orange: #ff7f32;
+  --color-pink: #ec008c;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  --color-background: #f9f9f9;
+  --color-surface: #ffffff;
+  --color-text: #333333;
+  --color-border: #e0e0e0;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: var(--color-background);
+  color: var(--color-text);
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+h1,
+ h2 {
+  color: var(--color-purple);
+  margin-top: 0;
+}
+
+form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+input,
+select {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background: var(--color-blue);
+  color: #fff;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  font-size: 0.9rem;
+  transition: background 0.2s;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+button:hover {
+  background: var(--color-green);
+}
+
+button.btn-secondary {
+  background: var(--color-orange);
+}
+
+button.btn-danger {
+  background: var(--color-pink);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+thead {
+  background: var(--color-blue);
+  color: #fff;
+}
+
+th,
+td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+}
+
+tbody tr:nth-child(odd) {
+  background: var(--color-surface);
+}
+
+tbody tr:nth-child(even) {
+  background: #f1f1f1;
+}
+
+tbody tr:hover {
+  background: var(--color-yellow);
+}
+
+td.actions {
+  white-space: nowrap;
+}
+
+.record-card {
+  margin-top: 2rem;
+  padding: 1rem;
+  max-width: 400px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  border-radius: 4px;
 }


### PR DESCRIPTION
## Summary
- apply rainbow color palette and global styles for buttons, forms, and tables
- replace list view with a table layout to align actions and improve clarity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68af487ebbc4832e9d525da6d78b1034