### PR TITLE
Add mandatory Added to Go field and format date displays

### DIFF
--- a/backend/sql/create_girls_table.sql
+++ b/backend/sql/create_girls_table.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS girls (
   first_name VARCHAR(100) NOT NULL,
   last_name VARCHAR(100) NOT NULL,
   date_of_birth DATE NOT NULL,
+  added_to_go DATE NOT NULL,
   state VARCHAR(20) NOT NULL CHECK (state IN (
     'Registered', 'Approved', 'Member', 'Leaver', 'Left', 'Rejected'
   ))

--- a/backend/src/routes/girls.js
+++ b/backend/src/routes/girls.js
@@ -7,7 +7,7 @@ const router = Router();
 router.get('/', async (req, res, next) => {
   try {
     const { state } = req.query;
-    const base = 'SELECT id, first_name, last_name, date_of_birth, state FROM girls';
+    const base = 'SELECT id, first_name, last_name, date_of_birth, added_to_go, state FROM girls';
     const sql = state ? `${base} WHERE state = $1 ORDER BY id` : `${base} ORDER BY id`;
     const params = state ? [state] : [];
     const { rows } = await query(sql, params);
@@ -18,7 +18,7 @@ router.get('/', async (req, res, next) => {
 router.get('/:id', async (req, res, next) => {
   try {
     const { rows } = await query(
-      'SELECT id, first_name, last_name, date_of_birth, state FROM girls WHERE id = $1',
+      'SELECT id, first_name, last_name, date_of_birth, added_to_go, state FROM girls WHERE id = $1',
       [req.params.id]
     );
     if (!rows.length) return res.status(404).json({ error: 'Not found' });
@@ -28,12 +28,12 @@ router.get('/:id', async (req, res, next) => {
 
 router.post('/', async (req, res, next) => {
   try {
-    const { first_name, last_name, date_of_birth, state } = req.body;
+    const { first_name, last_name, date_of_birth, added_to_go, state } = req.body;
     const { rows } = await query(
-      `INSERT INTO girls (first_name, last_name, date_of_birth, state)
-       VALUES ($1, $2, $3, $4)
-       RETURNING id, first_name, last_name, date_of_birth, state`,
-      [first_name, last_name, date_of_birth, state]
+      `INSERT INTO girls (first_name, last_name, date_of_birth, added_to_go, state)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING id, first_name, last_name, date_of_birth, added_to_go, state`,
+      [first_name, last_name, date_of_birth, added_to_go, state]
     );
     res.status(201).json(rows[0]);
   } catch (e) { next(e); }
@@ -41,7 +41,7 @@ router.post('/', async (req, res, next) => {
 
 router.patch('/:id', async (req, res, next) => {
   try {
-    const fields = ['first_name', 'last_name', 'date_of_birth', 'state'];
+    const fields = ['first_name', 'last_name', 'date_of_birth', 'added_to_go', 'state'];
     const updates = [];
     const values = [];
     fields.forEach((f) => {
@@ -55,7 +55,7 @@ router.patch('/:id', async (req, res, next) => {
 
     const { rows } = await query(
       `UPDATE girls SET ${updates.join(', ')} WHERE id = $${values.length}
-       RETURNING id, first_name, last_name, date_of_birth, state`,
+       RETURNING id, first_name, last_name, date_of_birth, added_to_go, state`,
       values
     );
     if (!rows.length) return res.status(404).json({ error: 'Not found' });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ function App() {
     first_name: "",
     last_name: "",
     date_of_birth: "",
+    added_to_go: "",
     state: "Member",
   };
 
@@ -14,6 +15,10 @@ function App() {
   const [editingId, setEditingId] = useState(null);
   const [editForm, setEditForm] = useState({ ...empty });
   const [record, setRecord] = useState(null);
+
+  function formatDate(str) {
+    return new Date(str).toLocaleDateString("en-GB");
+  }
 
   // Load data on mount
   useEffect(() => {
@@ -38,6 +43,7 @@ function App() {
       first_name: g.first_name,
       last_name: g.last_name,
       date_of_birth: g.date_of_birth,
+      added_to_go: g.added_to_go,
       state: g.state,
     });
   }
@@ -82,6 +88,12 @@ function App() {
           onChange={(e) => setForm({ ...form, date_of_birth: e.target.value })}
           required
         />
+        <input
+          type="date"
+          value={form.added_to_go}
+          onChange={(e) => setForm({ ...form, added_to_go: e.target.value })}
+          required
+        />
         <select
           value={form.state}
           onChange={(e) => setForm({ ...form, state: e.target.value })}
@@ -102,6 +114,7 @@ function App() {
             <th>First Name</th>
             <th>Last Name</th>
             <th>Date of Birth</th>
+            <th>Added to Go</th>
             <th>State</th>
             <th>Actions</th>
           </tr>
@@ -144,6 +157,19 @@ function App() {
                   />
                 </td>
                 <td>
+                  <input
+                    type="date"
+                    value={editForm.added_to_go}
+                    onChange={(e) =>
+                      setEditForm({
+                        ...editForm,
+                        added_to_go: e.target.value,
+                      })
+                    }
+                    required
+                  />
+                </td>
+                <td>
                   <select
                     value={editForm.state}
                     onChange={(e) =>
@@ -179,7 +205,8 @@ function App() {
               <tr key={g.id}>
                 <td>{g.first_name}</td>
                 <td>{g.last_name}</td>
-                <td>{g.date_of_birth}</td>
+                <td>{formatDate(g.date_of_birth)}</td>
+                <td>{formatDate(g.added_to_go)}</td>
                 <td>{g.state}</td>
                 <td className="actions">
                   <button
@@ -215,7 +242,8 @@ function App() {
           <h2>
             Record for {record.first_name} {record.last_name}
           </h2>
-          <p>Date of Birth: {record.date_of_birth}</p>
+          <p>Date of Birth: {formatDate(record.date_of_birth)}</p>
+          <p>Added to Go: {formatDate(record.added_to_go)}</p>
           <p>State: {record.state}</p>
           <button
             type="button"


### PR DESCRIPTION
## Summary
- add `added_to_go` date column to girls table and API
- show Added to Go on frontend with dd/mm/yyyy formatting
- format all date fields with `en-GB` locale

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b0a60095e0832e916d34909f7d4534